### PR TITLE
Finish up process_layer

### DIFF
--- a/xs/src/libslic3r/ExtrusionEntity.hpp
+++ b/xs/src/libslic3r/ExtrusionEntity.hpp
@@ -52,6 +52,9 @@ public:
     virtual double min_mm3_per_mm() const = 0;
     virtual Polyline as_polyline() const = 0;
     virtual double length() const { return 0; };
+    virtual bool is_perimeter() const {return false;};
+    virtual bool is_infill() const {return false;};
+    virtual bool is_solid_infill() const {return false;};
 };
 
 typedef std::vector<ExtrusionEntity*> ExtrusionEntitiesPtr;

--- a/xs/src/libslic3r/PrintGCode.hpp
+++ b/xs/src/libslic3r/PrintGCode.hpp
@@ -61,7 +61,11 @@ private:
     /// Utility function to print config options as gcode comments
     void _print_config(const ConfigBase& config);
 
+    // Extrude perimeters: Decide where to put seams (hide or align seams).
+    std::string _extrude_perimeters(std::map<size_t,ExtrusionEntityCollection> &by_region);
 
+    // Chain the paths hierarchically by a greedy algorithm to minimize a travel distance.
+    std::string _extrude_infill(std::map<size_t,ExtrusionEntityCollection> &by_region);
 };
 
 } // namespace Slic3r


### PR DESCRIPTION
`by_extruder` seems really messy to me, but I don't really see a way to simplify it.

I moved `is_solid_infill` and friends into `ExtrusionEntity` which revealed that `ExtrusionEntityCollection` extends `ExtrusionEntity` which seems really strange to me especially given that many methods that take an `ExtrusionEntity` would error on a collection.