### PR TITLE
Fix two small compilation issues

### DIFF
--- a/src/GUI/OptionsGroup/UI_Slider.cpp
+++ b/src/GUI/OptionsGroup/UI_Slider.cpp
@@ -73,7 +73,7 @@ int UI_Slider::get_int() {
 }
 
 std::string UI_Slider::get_string() {
-    return trim_zeroes(std::to_string(static_cast<double>(this->_slider->GetValue()) / this->_scale));
+    return _trim_zeroes(std::to_string(static_cast<double>(this->_slider->GetValue()) / this->_scale));
 }
 
 void UI_Slider::set_scale(size_t new_scale) {

--- a/src/test/test_data.cpp
+++ b/src/test/test_data.cpp
@@ -12,7 +12,7 @@ using namespace std;
 namespace Slic3r { namespace Test {
 
 // Mesh enumeration to name mapping
-const std::unordered_map<TestMesh, const char*> mesh_names { 
+const std::unordered_map<TestMesh, const char*, TestMeshHash> mesh_names {
     std::make_pair<TestMesh, const char*>(TestMesh::A,"A"),
     std::make_pair<TestMesh, const char*>(TestMesh::L,"L"), 
     std::make_pair<TestMesh, const char*>(TestMesh::V,"V"), 

--- a/src/test/test_data.hpp
+++ b/src/test/test_data.hpp
@@ -33,8 +33,15 @@ enum class TestMesh {
     two_hollow_squares
 };
 
+// Neccessary for <c++17
+struct TestMeshHash {
+    std::size_t operator()(TestMesh tm) const {
+        return static_cast<std::size_t>(tm);
+    }
+};
+
 /// Mesh enumeration to name mapping
-extern const std::unordered_map<TestMesh, const char*> mesh_names;
+extern const std::unordered_map<TestMesh, const char*, TestMeshHash> mesh_names;
 
 /// Port of Slic3r::Test::mesh
 /// Basic cubes/boxes should call TriangleMesh::make_cube() directly and rescale/translate it


### PR DESCRIPTION
This fixes the issue with test_data I was having; it was just that `std::hash` isn't specialized for enums until c++17.

And additionally fixes a error where the compiler tries to use `wxString Slic3r::GUI::trim_zeroes (wxString)` instead of `std::string trim_zeroes(std::string)`. This seems to be because it is called in the namespace `Slic3r::GUI`, but I don't know exactly why.